### PR TITLE
Jg/network metrics

### DIFF
--- a/src/pmeter/constants.py
+++ b/src/pmeter/constants.py
@@ -1,0 +1,15 @@
+class NetworkMetrics:
+    BANDWIDTH="bandwith"
+    PACKET_LOSS="packet_loss"
+    LINK_CAPACTITY="link_capacity"
+    ROUND_TRIP_TIME="round_trip_time"
+    BANDWIDTH_DELAY_PRODUT="bandwidth_delay_product"
+
+class KernelMetrics:
+    ACTIVE_CORES="active_cores"
+    CPU_FREQUENCY="cpu_frequency"
+    ENERGY_CONSUMPTION="energy_consumption"
+    CPU_ARCHITECTURE="cpu_architecture"
+    NETWORK_CARD_USAGE="nic_usage"
+    CPU_USAGE="cpu_usage"
+

--- a/src/pmeter/constants.py
+++ b/src/pmeter/constants.py
@@ -13,3 +13,21 @@ class KernelMetrics:
     NETWORK_CARD_USAGE="nic_usage"
     CPU_USAGE="cpu_usage"
 
+#Found this function here https://www.admin-magazine.com/HPC/Articles/Process-Network-and-Disk-Metrics
+def bytes2human(n):
+       # From sample script for psutils
+   """
+   >>> bytes2human(10000)
+   '9.8 K'
+   >>> bytes2human(100001221)
+   '95.4 M'
+   """
+   symbols = ('K', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y')
+   prefix = {}
+   for i, s in enumerate(symbols):
+      prefix[s] = 1 << (i + 1) * 10
+   for s in reversed(symbols):
+      if n >= prefix[s]:
+         value = float(n) / prefix[s]
+         return '%.2f %s' % (value, s)
+   return '%.2f B' % (n)

--- a/src/pmeter/file_writer.py
+++ b/src/pmeter/file_writer.py
@@ -1,0 +1,55 @@
+from email.policy import default
+import multiprocessing
+import json
+from datetime import date, datetime
+
+
+class ODS_Metrics():
+
+    def __init__(self):
+        #kernel metrics 
+        self.active_core_count = 0
+        self.cpu_frequency = 0.0
+        self.energy_consumed = 0.0
+        self.cpu_arch = ""
+        #network metrics
+        self.rtt = 0.0
+        self.bandwidth = 0.0
+        self.bandwidth_delay_product = 0.0
+        self.packet_loss_rate = 0.0
+        self.link_capacity = 0.0
+        #identifying properties
+        self.start_time=""
+        self.end_time=""
+        self.count = 0
+
+    def active_core_count(self):
+        self.active_core_count = multiprocessing.cpu_count()
+
+    def to_file(self, file_name):
+        j = json.dumps(self.__dict__)
+        with open(file_name, "a+") as f:
+            f.write(j)
+    
+    def measure(self, measure_tcp=True, measure_udp=True, measure_kernel=True, measure_network=True, print_to_std_out=False):
+        self.start_time = datetime.now().__str__()
+
+        if measure_kernel:
+            self.active_core_count = multiprocessing.cpu_count()
+        if measure_network:
+            print('Measuring your network')
+        if measure_tcp:
+            print('Measuring tcp')
+        if measure_udp:
+            print('Measuring udp')
+
+        self.end_time=datetime.now().__str__()
+        if(print_to_std_out):
+            print(json.dumps(self.__dict__))
+        
+        self.to_file("pmeter_measure.txt")
+
+    def defaultconverter(o):
+        if isinstance(o, datetime.datetime):
+            return o.__str__()
+

--- a/src/pmeter/file_writer.py
+++ b/src/pmeter/file_writer.py
@@ -54,16 +54,17 @@ class ODS_Metrics():
         if measure_network:
             print('Getting metrics of: ' + interface)
             nic_counter_dic = psutil.net_io_counters(pernic=True)
-            interface_counter_dic = nic_counter_dic[interface]
-            print(interface_counter_dic)
-            self.bytes_sent = interface_counter_dic['bytes_sent']
-            self.bytes_recv = interface_counter_dic['bytes_recv']
-            self.packets_sent = interface_counter_dic['packets_sent']
-            self.packets_recv = interface_counter_dic['packets_recv']
-            self.errin = interface_counter_dic['errin']
-            self.errout = interface_counter_dic['errout']
-            self.dropin = interface_counter_dic['dropin']
-            self.dropout = interface_counter_dic['dropout']
+            interface_counter_tuple = nic_counter_dic[interface]
+            print(interface_counter_tuple)
+            # snetio(bytes_sent=179353738, bytes_recv=1961293807, packets_sent=1699113, packets_recv=2477127, errin=0, errout=0, dropin=0, dropout=0)
+            self.bytes_sent = interface_counter_tuple[0]
+            self.bytes_recv = interface_counter_tuple[1]
+            self.packets_sent = interface_counter_tuple[2]
+            self.packets_recv = interface_counter_tuple[3]
+            self.errin = interface_counter_tuple[4]
+            self.errout = interface_counter_tuple[5]
+            self.dropin = interface_counter_tuple[6]
+            self.dropout = interface_counter_tuple[7]
             sys_interfaces = psutil.net_if_stats()
             interface_stats = sys_interfaces[self.interface]
             print(interface_stats)

--- a/src/pmeter/file_writer.py
+++ b/src/pmeter/file_writer.py
@@ -4,6 +4,7 @@ import json
 from datetime import date, datetime
 import psutil
 import platform
+from tcp_latency import measure_latency
 
 
 class ODS_Metrics():
@@ -33,6 +34,7 @@ class ODS_Metrics():
         self.start_time=""
         self.end_time=""
         self.count = 0
+        self.latency = []
 
     # def active_core_count(self):
     #     self.active_core_count = multiprocessing.cpu_count()
@@ -42,7 +44,7 @@ class ODS_Metrics():
         with open(file_name, "a+") as f:
             f.write(j + "\n")
     
-    def measure(self, interface='', measure_tcp=True, measure_udp=True, measure_kernel=True, measure_network=True, print_to_std_out=False):
+    def measure(self, interface='', measure_tcp=True, measure_udp=True, measure_kernel=True, measure_network=True, print_to_std_out=False, latency_host="http://google.com"):
         self.start_time = datetime.now().__str__()
         self.interface = interface
         if measure_kernel:
@@ -65,13 +67,13 @@ class ODS_Metrics():
             interface_stats = sys_interfaces[self.interface]
             self.nic_mtu = interface_stats['mtu']
             self.nic_speed = interface_stats['speed']
+            self.latency = measure_latency(host='google.com')
         if measure_tcp:
             print('Measuring tcp')
             psutil.net_connections(kind="tcp")
         if measure_udp:
             print('Measuring udp')
             psutil.net_connections(kind="udp")
-
         self.end_time=datetime.now().__str__()
         if(print_to_std_out):
             print(json.dumps(self.__dict__))

--- a/src/pmeter/file_writer.py
+++ b/src/pmeter/file_writer.py
@@ -68,8 +68,9 @@ class ODS_Metrics():
             sys_interfaces = psutil.net_if_stats()
             interface_stats = sys_interfaces[self.interface]
             print(interface_stats)
-            self.nic_mtu = interface_stats['mtu']
-            self.nic_speed = interface_stats['speed']
+            # snicstats(isup=True, duplex=<NicDuplex.NIC_DUPLEX_UNKNOWN: 0>, speed=0, mtu=9001)
+            self.nic_mtu = interface_stats[3]
+            self.nic_speed = interface_stats[2]
             self.latency = measure_latency(host='google.com')
         if measure_tcp:
             print('Measuring tcp')

--- a/src/pmeter/file_writer.py
+++ b/src/pmeter/file_writer.py
@@ -55,6 +55,7 @@ class ODS_Metrics():
             print('Getting metrics of: ' + interface)
             nic_counter_dic = psutil.net_io_counters(pernic=True)
             interface_counter_dic = nic_counter_dic[interface]
+            print(interface_counter_dic)
             self.bytes_sent = interface_counter_dic['bytes_sent']
             self.bytes_recv = interface_counter_dic['bytes_recv']
             self.packets_sent = interface_counter_dic['packets_sent']
@@ -65,6 +66,7 @@ class ODS_Metrics():
             self.dropout = interface_counter_dic['dropout']
             sys_interfaces = psutil.net_if_stats()
             interface_stats = sys_interfaces[self.interface]
+            print(interface_stats)
             self.nic_mtu = interface_stats['mtu']
             self.nic_speed = interface_stats['speed']
             self.latency = measure_latency(host='google.com')

--- a/src/pmeter/file_writer.py
+++ b/src/pmeter/file_writer.py
@@ -72,6 +72,7 @@ class ODS_Metrics():
             self.nic_mtu = interface_stats[3]
             self.nic_speed = interface_stats[2]
             self.latency = measure_latency(host='google.com')
+            print(self.latency)
         if measure_tcp:
             print('Measuring tcp')
             psutil.net_connections(kind="tcp")

--- a/src/pmeter/file_writer.py
+++ b/src/pmeter/file_writer.py
@@ -2,6 +2,8 @@ from email.policy import default
 import multiprocessing
 import json
 from datetime import date, datetime
+import psutil
+import platform
 
 
 class ODS_Metrics():
@@ -18,30 +20,41 @@ class ODS_Metrics():
         self.bandwidth_delay_product = 0.0
         self.packet_loss_rate = 0.0
         self.link_capacity = 0.0
+        self.bytes_sent = 0.0
+        self.bytes_recv = 0.0
+        self.packets_sent = 0
+        self.packets_recv = 0
+        self.dropin = 0
+        self.dropout = 0
         #identifying properties
         self.start_time=""
         self.end_time=""
         self.count = 0
 
-    def active_core_count(self):
-        self.active_core_count = multiprocessing.cpu_count()
+    # def active_core_count(self):
+    #     self.active_core_count = multiprocessing.cpu_count()
 
     def to_file(self, file_name):
         j = json.dumps(self.__dict__)
         with open(file_name, "a+") as f:
-            f.write(j)
+            f.write(j + "\n")
     
     def measure(self, measure_tcp=True, measure_udp=True, measure_kernel=True, measure_network=True, print_to_std_out=False):
         self.start_time = datetime.now().__str__()
 
         if measure_kernel:
             self.active_core_count = multiprocessing.cpu_count()
+            self.cpu_frequency = psutil.cpu_freq()
+            self.cpu_arch = platform.platform()
         if measure_network:
             print('Measuring your network')
+            print(psutil.net_if_stats())
         if measure_tcp:
             print('Measuring tcp')
+            psutil.net_connections(kind="tcp")
         if measure_udp:
             print('Measuring udp')
+            psutil.net_connections(kind="udp")
 
         self.end_time=datetime.now().__str__()
         if(print_to_std_out):

--- a/src/pmeter/file_writer.py
+++ b/src/pmeter/file_writer.py
@@ -15,6 +15,7 @@ class ODS_Metrics():
         self.energy_consumed = 0.0
         self.cpu_arch = ""
         #network metrics
+        self.interface= ""
         self.rtt = 0.0
         self.bandwidth = 0.0
         self.bandwidth_delay_product = 0.0
@@ -26,6 +27,8 @@ class ODS_Metrics():
         self.packets_recv = 0
         self.dropin = 0
         self.dropout = 0
+        self.nic_speed = 0 #this is in mb=megabits
+        self.nic_mtu = 0 #max transmission speed of nic
         #identifying properties
         self.start_time=""
         self.end_time=""
@@ -39,16 +42,29 @@ class ODS_Metrics():
         with open(file_name, "a+") as f:
             f.write(j + "\n")
     
-    def measure(self, measure_tcp=True, measure_udp=True, measure_kernel=True, measure_network=True, print_to_std_out=False):
+    def measure(self, interface='', measure_tcp=True, measure_udp=True, measure_kernel=True, measure_network=True, print_to_std_out=False):
         self.start_time = datetime.now().__str__()
-
+        self.interface = interface
         if measure_kernel:
             self.active_core_count = multiprocessing.cpu_count()
             self.cpu_frequency = psutil.cpu_freq()
             self.cpu_arch = platform.platform()
         if measure_network:
-            print('Measuring your network')
-            print(psutil.net_if_stats())
+            print('Getting metrics of: ' + interface)
+            nic_counter_dic = psutil.net_io_counters(pernic=True)
+            interface_counter_dic = nic_counter_dic[interface]
+            self.bytes_sent = interface_counter_dic['bytes_sent']
+            self.bytes_recv = interface_counter_dic['bytes_recv']
+            self.packets_sent = interface_counter_dic['packets_sent']
+            self.packets_recv = interface_counter_dic['packets_recv']
+            self.errin = interface_counter_dic['errin']
+            self.errout = interface_counter_dic['errout']
+            self.dropin = interface_counter_dic['dropin']
+            self.dropout = interface_counter_dic['dropout']
+            sys_interfaces = psutil.net_if_stats()
+            interface_stats = sys_interfaces[self.interface]
+            self.nic_mtu = interface_stats['mtu']
+            self.nic_speed = interface_stats['speed']
         if measure_tcp:
             print('Measuring tcp')
             psutil.net_connections(kind="tcp")

--- a/src/pmeter/pmeter_cli.py
+++ b/src/pmeter/pmeter_cli.py
@@ -27,6 +27,7 @@ if __name__ == '__main__':
     arguments = docopt(__doc__, version='Naval Fate 2.0')
     print(arguments)
     if arguments['measure']:
+        interface = arguments['<INTERFACE>']
         file_name = arguments['--file_name']
         network_only = arguments['--measure_network']
         kernel_only = arguments['--measure_kernel']
@@ -34,5 +35,5 @@ if __name__ == '__main__':
         tcp_only = arguments['--measure_tcp']
         std_out_print = arguments['--enable_std_out']
         metrics = ODS_Metrics()
-        metrics.measure(measure_tcp=tcp_only, measure_kernel=kernel_only, measure_network=network_only, measure_udp=udp_only, print_to_std_out=std_out_print)
+        metrics.measure(interface=interface,measure_tcp=tcp_only, measure_kernel=kernel_only, measure_network=network_only, measure_udp=udp_only, print_to_std_out=std_out_print)
         print('In Measure')

--- a/src/pmeter/pmeter_cli.py
+++ b/src/pmeter/pmeter_cli.py
@@ -1,7 +1,7 @@
 """PMeter a tool to measure the TCP/UDP network conditions that the running host experiences
 
 Usage:
-  pmeter_cli.py measure <INTERFACE>... [-K=KER_BOOL -N=NET_BOOL -F=FILE_NAME -S=STD_OUT_BOOL -time_length=RUN_FOR]
+  pmeter_cli.py measure <INTERFACE> [-K=KER_BOOL -N=NET_BOOL -F=FILE_NAME -S=STD_OUT_BOOL -time_length=RUN_FOR]
 
 Commands:
     measure     The command to start measuring the computers network activity on the specified network devices. This command accepts a list of interfaces that you wish to monitor

--- a/src/pmeter/pmeter_cli.py
+++ b/src/pmeter/pmeter_cli.py
@@ -1,0 +1,38 @@
+"""PMeter a tool to measure the TCP/UDP network conditions that the running host experiences
+
+Usage:
+  pmeter_cli.py measure <INTERFACE>... [-K=KER_BOOL -N=NET_BOOL -F=FILE_NAME -S=STD_OUT_BOOL -time_length=RUN_FOR]
+
+Commands:
+    measure     The command to start measuring the computers network activity on the specified network devices. This command accepts a list of interfaces that you wish to monitor
+
+Options:
+  -h --help                Show this screen
+  --version                Show version
+  -F --file_name           Set the file name used to measure [default: network_results.txt]
+  -N --measure_network     Set if we monitor only the network interface [default: True]
+  -K --measure_kernel      Set if we monitor only the kernel [default: True]
+  -U --measure_udp         Set UDP monitoring only [default: True]
+  -T --measure_tcp         Set TCP monitoring only [default: True]
+  -S --enable_std_out      Disable printing the results to standard output [default: False]
+  -time_length             Set the time to run the measurement in the format HH:MM:SS [default:00:00:02]
+"""
+from docopt import docopt
+import multiprocessing
+
+from file_writer import ODS_Metrics
+
+
+if __name__ == '__main__':
+    arguments = docopt(__doc__, version='Naval Fate 2.0')
+    print(arguments)
+    if arguments['measure']:
+        file_name = arguments['--file_name']
+        network_only = arguments['--measure_network']
+        kernel_only = arguments['--measure_kernel']
+        udp_only = arguments['--measure_udp']
+        tcp_only = arguments['--measure_tcp']
+        std_out_print = arguments['--enable_std_out']
+        metrics = ODS_Metrics()
+        metrics.measure(measure_tcp=tcp_only, measure_kernel=kernel_only, measure_network=network_only, measure_udp=udp_only, print_to_std_out=std_out_print)
+        print('In Measure')


### PR DESCRIPTION
Metrics added to this pr:

- cpu_frequency: hz of the core
- cpu_arch: architecture that the cpu has
- interface: the interface the user passed in to query
- bytes_sent: the bytes sent through the selected interface
- bytes_recv: the bytes received through the selected interface
- packets_sent: the number of packets sent through the interface
- packets_recv: the number of packets recieved through the interface
- dropin: the number of dropped packets in the selected interface
- dropout: the number of dropped packets in the selected interface
- nic_speed: the speed of the network interface selected
- nic_mtu: the maximum transmission network interface
- latency : the latency measured to the default host (http://google.com)